### PR TITLE
fix: vcpkg install dependencies on specific archs

### DIFF
--- a/src/vcpkg/devcontainer-feature.json
+++ b/src/vcpkg/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Vcpkg Tool",
   "id": "vcpkg",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "documentationURL": "https://github.com/msclock/features/tree/main/src/vcpkg",
   "description": "A vcpkg tool feature",
   "options": {

--- a/src/vcpkg/main.sh
+++ b/src/vcpkg/main.sh
@@ -278,6 +278,18 @@ else
         exit 1
     fi
 fi
+
+# https://github.com/microsoft/vcpkg-tool/blob/2024-03-29/src/vcpkg.cpp#L273C80-L277
+arch=$(uname -m)
+
+if [[ "$arch" == *"arm"* ]] ||
+   [[ "$arch" == *"aarch"* ]] ||
+   [[ "$arch" == *"riscv"* ]] ||
+   [[ "$arch" == "s390x" ]] ||
+   [[ "$arch" == *"ppc64"* ]]; then
+    VCPKG_FORCE_SYSTEM_BINARIES=1
+fi
+
 ## Run installer to get latest stable vcpkg binary
 ## https://github.com/microsoft/vcpkg/blob/7e7dad5fe20cdc085731343e0e197a7ae655555b/scripts/bootstrap.sh#L126-L144
 "${VCPKG_ROOT}"/bootstrap-vcpkg.sh
@@ -312,13 +324,7 @@ updaterc "$(
 export VCPKG_ROOT="${VCPKG_ROOT}"
 if [[ "\${PATH}" != *"\${VCPKG_ROOT}"* ]]; then export PATH="\${VCPKG_ROOT}:\${PATH}"; fi
 # https://github.com/microsoft/vcpkg-tool/blob/2024-03-29/src/vcpkg.cpp#L273C80-L277
-if [[ "\$(uname -m)" == *"arm"* ]] ||
-   [[ "\$(uname -m)" == *"aarch"* ]] ||
-   [[ "\$(uname -m)" == *"riscv"* ]] ||
-   [[ "\$(uname -m)" == "s390x" ]] ||
-   [[ "\$(uname -m)" == *"ppc64"* ]]; then
-    export VCPKG_FORCE_SYSTEM_BINARIES=1
-fi
+if [[ -n "$VCPKG_FORCE_SYSTEM_BINARIES" ]]; then export VCPKG_FORCE_SYSTEM_BINARIES=1; fi
 EOF
 )"
 


### PR DESCRIPTION
specifich archs include: arm, aarch, riscv, s3890, ppc64. See <https://github.com/microsoft/vcpkg-tool/blob/2024-03-29/src/vcpkg.cpp#L273C80-L277>

Close #15 